### PR TITLE
Update metadata.json for GNOME42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,5 @@
   "uuid": "overview-navigation@nathanielsimard.github.com",
   "settings-schema": "org.gnome.shell.extensions.overview-navigation",
   "url": "https://github.com/nathanielsimard/overview-navigation",
-  "shell-version": ["41"]
+  "shell-version": ["42"]
 }


### PR DESCRIPTION
It works fine in gnome42, and please update it in [extensions website](https://extensions.gnome.org/extension/1702/overview-navigation/)