### PR TITLE
add preference dialog for closing hint color

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -38,9 +38,15 @@ class SettingsUI extends Widget {
       this.logger
     )
     const fontColorText = new ColorChooserWidget(
-      'Hint font color',
+      'Hint focusing font color',
       this.settings,
       this.properties.HINT_FONT_COLOR,
+      this.logger
+    )
+    const closingFontColorText = new ColorChooserWidget(
+      'Hint closing font color',
+      this.settings,
+      this.properties.HINT_CLOSING_FONT_COLOR,
       this.logger
     )
     const borderColor = new ColorChooserWidget(
@@ -58,6 +64,7 @@ class SettingsUI extends Widget {
 
     style.append(backgroundColorText)
     style.append(fontColorText)
+    style.append(closingFontColorText)
     style.append(borderColor)
     style.append(borderSize)
     style.register(this.notebook)


### PR DESCRIPTION
Make it possible to change the color of the hint that closes the window. There was already some code around to make that work (for example, the constant "HINT_CLOSING_FONT_COLOR" in the settings.js file), so this was most likely an intended feature.

Already tested locally and it is working:
![image](https://user-images.githubusercontent.com/65264536/189761206-cd1b222d-a75f-4090-85a4-2d8546abf472.png)

Thanks for developing this extension, I use it literally everyday 🚀
